### PR TITLE
Fix canvas size issue

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3,15 +3,22 @@ class Game {
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
         
+        // Set base canvas size
+        const baseWidth = 800;
+        const baseHeight = 600;
+        
         // Handle high DPI displays
         const dpr = window.devicePixelRatio || 1;
-        const rect = this.canvas.getBoundingClientRect();
         
-        this.canvas.width = rect.width * dpr;
-        this.canvas.height = rect.height * dpr;
-        this.canvas.style.width = `${rect.width}px`;
-        this.canvas.style.height = `${rect.height}px`;
+        // Set display size
+        this.canvas.style.width = `${baseWidth}px`;
+        this.canvas.style.height = `${baseHeight}px`;
         
+        // Set actual size in memory (scaled for DPI)
+        this.canvas.width = baseWidth * dpr;
+        this.canvas.height = baseHeight * dpr;
+        
+        // Scale all drawing operations by the dpr
         this.ctx.scale(dpr, dpr);
         
         this.player = null;


### PR DESCRIPTION
This PR fixes the canvas size issue:

1. Problem:
- Canvas was getting its initial size from getBoundingClientRect() before size was set
- This caused the canvas to be very small initially
- DPI scaling was making the issue worse

2. Solution:
- Set base canvas size (800x600) first
- Then apply DPI scaling
- Maintain correct display size

3. Changes:
- Remove getBoundingClientRect() usage
- Set explicit base dimensions
- Apply DPI scaling correctly

After this fix, the game should:
- Display at the correct 800x600 size
- Support high DPI displays properly
- Maintain aspect ratio
- Look crisp on all displays