### PR TITLE
Fix audio error

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     </div>
     <script src="js/utils.js"></script>
     <script src="js/resourceLoader.js"></script>
+    <script src="js/audioManager.js"></script>
     <script src="js/player.js"></script>
     <script src="js/obstacles.js"></script>
     <script src="js/collectibles.js"></script>


### PR DESCRIPTION
This PR fixes the audio error by adding back the missing audioManager.js script.

Problem:
- Error: Cannot read properties of undefined (reading playSound)
- Caused by missing audioManager.js in HTML

Fix:
- Add audioManager.js script back to index.html

Simple fix that should resolve the audio error without introducing new complexity.