### PR TITLE
Fix image loading error

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     </div>
     <script src="js/utils.js"></script>
     <script src="js/resourceLoader.js"></script>
+    <script src="js/imageLoader.js"></script>
     <script src="js/player.js"></script>
     <script src="js/obstacles.js"></script>
     <script src="js/collectibles.js"></script>


### PR DESCRIPTION
This PR fixes the image loading error by adding back imageLoader.js script.

Problem:
- Error: Cannot read properties of undefined (reading getImage)
- Caused by missing imageLoader.js in HTML

Fix:
- Add imageLoader.js script to index.html

Simple fix that should resolve the image loading error.