### PR TITLE
Fix collectible images

### DIFF
--- a/js/collectibles.js
+++ b/js/collectibles.js
@@ -71,7 +71,7 @@ class Collectible {
     render(ctx) {
         if (!this.active) return;
 
-        const img = window.imageLoader.getImage(this.type);
+        const img = window.resourceLoader.getImage(this.type);
         if (!img) {
             console.warn(`Image not found for collectible type: ${this.type}`);
             // Fallback rendering


### PR DESCRIPTION
This PR fixes the collectible images by using resourceLoader instead of imageLoader.

Problem:
- Error: Image not found for collectible type: paperclip
- Caused by using old imageLoader instead of new resourceLoader

Fix:
- Update collectibles.js to use resourceLoader.getImage()

Simple fix that should make collectible images appear correctly.