### PR TITLE
Fix resource loading

### DIFF
--- a/js/resourceLoader.js
+++ b/js/resourceLoader.js
@@ -208,6 +208,7 @@ class ResourceLoader {
 }
 
 // Create global instance when DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     window.resourceLoader = new ResourceLoader();
+    await window.resourceLoader.loadAll();
 });


### PR DESCRIPTION
This PR fixes the resource loading by loading resources immediately after creating resourceLoader.

Problem:
- Images not found because they were not loaded yet
- resourceLoader was created but loadAll() was not called

Fix:
- Call loadAll() immediately after creating resourceLoader

Simple fix that ensures resources are loaded before they are needed.