### PR TITLE
Fix obstacle images

### DIFF
--- a/js/obstacles.js
+++ b/js/obstacles.js
@@ -52,7 +52,7 @@ class Obstacle {
     }
 
     render(ctx) {
-        const img = window.imageLoader.getImage(this.type);
+        const img = window.resourceLoader.getImage(this.type);
         if (!img) return;
 
         ctx.save();


### PR DESCRIPTION
This PR fixes the obstacle images by using resourceLoader instead of imageLoader.

Problem:
- Obstacles were not visible
- Using old imageLoader instead of new resourceLoader

Fix:
- Update obstacles.js to use resourceLoader.getImage()

Simple fix that should make obstacles appear correctly.