### PR TITLE
Keep background music playing

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -409,6 +409,9 @@ class Game {
     }
 
     gameOver() {
+        if (!this.isGameOver) {  // Only play sound if not already game over
+            window.audioManager.playSound('gameOver');
+        }
         this.isGameOver = true;
         this.showGameOverScreen();
     }
@@ -436,5 +439,7 @@ class Game {
 
 // Start the game when the page loads
 window.addEventListener('load', () => {
+    // Start background music as soon as the page loads
+    window.audioManager.playBackgroundMusic();
     new Game();
 });


### PR DESCRIPTION
This PR makes the background music play continuously.

Problem:
- Background music stops after game over
- Music needs to keep playing

Fix:
- Start music when page loads
- Never stop the music (even after game over)
- Only play game over sound effect

Simple fix that ensures continuous background music.