### PR TITLE
Fix music pause/resume

### DIFF
--- a/js/audioManager.js
+++ b/js/audioManager.js
@@ -34,10 +34,9 @@ class AudioManager {
         }
     }
 
-    stopBackgroundMusic() {
+    pauseBackgroundMusic() {
         if (this.backgroundMusic) {
             this.backgroundMusic.pause();
-            this.backgroundMusic.currentTime = 0;
         }
     }
 
@@ -54,7 +53,7 @@ class AudioManager {
     toggleMute() {
         this.isMuted = !this.isMuted;
         if (this.isMuted) {
-            this.stopBackgroundMusic();
+            this.pauseBackgroundMusic();
         } else {
             this.playBackgroundMusic();
         }


### PR DESCRIPTION
This PR fixes the background music to keep playing.

Problem:
- Music position was being reset when paused
- Music would restart from beginning when unmuted

Fix:
- Replace stopBackgroundMusic with pauseBackgroundMusic
- Keep music position when pausing/resuming
- Keep music position when toggling mute

Simple fix that ensures continuous background music.