### PR TITLE
Simplify music: Just keep playing

### DIFF
--- a/js/audioManager.js
+++ b/js/audioManager.js
@@ -34,13 +34,6 @@ class AudioManager {
         }
     }
 
-    stopBackgroundMusic() {
-        if (this.backgroundMusic) {
-            this.backgroundMusic.pause();
-            this.backgroundMusic.currentTime = 0;
-        }
-    }
-
     playSound(name) {
         if (this.isMuted || !this.sounds[name]) return;
 
@@ -54,9 +47,9 @@ class AudioManager {
     toggleMute() {
         this.isMuted = !this.isMuted;
         if (this.isMuted) {
-            this.stopBackgroundMusic();
+            this.backgroundMusic.volume = 0;
         } else {
-            this.playBackgroundMusic();
+            this.backgroundMusic.volume = 0.5;
         }
         return this.isMuted;
     }

--- a/js/game.js
+++ b/js/game.js
@@ -436,5 +436,7 @@ class Game {
 
 // Start the game when the page loads
 window.addEventListener('load', () => {
+    // Start background music as soon as the page loads
+    window.audioManager.playBackgroundMusic();
     new Game();
 });


### PR DESCRIPTION
This PR simplifies the background music to just keep playing.

Problem:
- Music was being stopped and started
- Too complex with pause/resume

Fix:
- Start music when page loads
- Never stop the music
- Just adjust volume for mute

Simple fix that ensures continuous background music.