### PR TITLE
Fix music handling

### DIFF
--- a/js/audioManager.js
+++ b/js/audioManager.js
@@ -54,9 +54,9 @@ class AudioManager {
     toggleMute() {
         this.isMuted = !this.isMuted;
         if (this.isMuted) {
-            this.stopBackgroundMusic();
+            this.backgroundMusic.volume = 0;
         } else {
-            this.playBackgroundMusic();
+            this.backgroundMusic.volume = 0.5;
         }
         return this.isMuted;
     }

--- a/js/game.js
+++ b/js/game.js
@@ -409,6 +409,9 @@ class Game {
     }
 
     gameOver() {
+        if (!this.isGameOver) {
+            window.audioManager.playSound('gameOver');
+        }
         this.isGameOver = true;
         this.showGameOverScreen();
     }


### PR DESCRIPTION
This PR fixes the music handling.

Problem:
- Game was crashing due to missing stopBackgroundMusic function
- Music was being stopped instead of just muted

Fix:
- Remove stopBackgroundMusic calls
- Just adjust volume for mute
- Add game over sound

Simple fix that ensures continuous background music.